### PR TITLE
Fixed typo in lib/dialogs.js

### DIFF
--- a/lib/dialogs.js
+++ b/lib/dialogs.js
@@ -306,7 +306,7 @@ async function warning(title, msg, buttons = [ 'Cancel', 'OK' ]) {
 }
 
 /**
- * Displays a warning dialog.
+ * Displays a prompt dialog.
  *
  * @param {string} title
  * @param {string} msg


### PR DESCRIPTION
# Submit a pull request

There was a typo in `lib/dialogs.js` file where prompt was referred as warning in docblock comment. Fixed!

## CLA
- [ ] I have signed the [Adobe CLA](http://adobe.github.io/cla.html) (required).

## Topic

This is a pull request for:

- [ ] A guide contained within this repo.
- [ ] A sample contained within this repo.
- [ ] Something new that I have already discussed with Adobe in a GitHub issue. Issue link:

## Versions

- [ ] XD version(s) tested :
- [ ] Tested XD version(s):

## Description of the pull request
